### PR TITLE
Fix a NPE with breakBlock

### DIFF
--- a/src/main/java/pcl/OpenFM/Block/BlockRadio.java
+++ b/src/main/java/pcl/OpenFM/Block/BlockRadio.java
@@ -106,6 +106,9 @@ public class BlockRadio extends Block implements ITileEntityProvider, IPeriphera
 	@Override
 	public void breakBlock(World world, int x, int y, int z, Block block, int p_149749_6_) {
 		TileEntityRadio t = (TileEntityRadio)world.getTileEntity(x, y, z);
+		if(t==null)
+			return;
+		
 		dropContent(t, world, t.xCoord, t.yCoord, t.zCoord);
 		ArrayList<ItemStack> items = new ArrayList<ItemStack>();
 		if (t instanceof TileEntityRadio) {


### PR DESCRIPTION
Fix a NPE when breakBlock is called when a tile has already been removed.

Log here: http://pastebin.com/VtgW93C7

Happens with http://github.com/darkevilmac/MovingWorld and potentially other mods as well.